### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/pyshop/views/simple.py
+++ b/pyshop/views/simple.py
@@ -171,9 +171,9 @@ class Show(View):
 
     def _to_unicode(self, data):
         # xmlrpc use utf8 encoded string
-        return dict([(key, val.decode('utf-8')
-                      if isinstance(val, str) else val)
-                     for key, val in data.items()])
+        return {key: val.decode('utf-8')
+                      if isinstance(val, str) else val
+                     for key, val in data.items()}
 
     def _create_release(self, package, data, session_users):
         log.info('Create release {0} for package {1}'.format(

--- a/pyshop/views/xmlrpc.py
+++ b/pyshop/views/xmlrpc.py
@@ -165,7 +165,7 @@ class PyPI(XMLRPCView):
                            'maintainer_email': release.maintainer.email,
                            })
 
-        return dict([(key, val or '') for key, val in result.items()])
+        return {key: val or '' for key, val in result.items()}
 
     def search(self, spec, operator='and'):
         """


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyshop?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:pyshop?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
